### PR TITLE
  Composer: Check for php version 7 dependency in composer.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,6 +34,7 @@
         "source": "https://github.com/itafroma/zork-php"
     },
     "require": {
+        "php": ">=7.0.0",
         "symfony/config": "~2.6",
         "symfony/dependency-injection": "~2.6",
         "symfony/yaml": "~2.6"


### PR DESCRIPTION
Since some of the syntax used is only available in php 7 RC, sadly: http://php.net/manual/en/migration70.new-features.php

Please check on your system, as I might be wrong about the reported version for a RC for 7, in which case this pull request should reflect your currently used version instead (at least until the november 2015 release date of 7).
